### PR TITLE
Using 2 pixscales for RA and DEC to account for different MAX of U and V.

### DIFF
--- a/src/images.cpp
+++ b/src/images.cpp
@@ -3,7 +3,7 @@
 #include <iomanip>
 
 namespace {
-        void save_fits_file(const std::string filename, float* data, long side_x, long side_y, double ra, double dec, double pixscale){
+        void save_fits_file(const std::string filename, float* data, long side_x, long side_y, double ra, double dec, double pixscale_ra, double pixscale_dec){
         FITS fitsImage;
         FITS::HDU hdu;
         hdu.set_image(data,  side_x, side_y);
@@ -13,13 +13,13 @@ namespace {
         // hdu.add_keyword("COARSE_CHAN", obsInfo.coarseChannel, "Receiver Coarse Channel Number (only used in offline mode)");
         hdu.add_keyword("CTYPE1", std::string { "RA---SIN"}, "");
         hdu.add_keyword("CRPIX1", side_x / 2 + 1, "" );   
-        hdu.add_keyword("CDELT1", pixscale, "Pixscale" );
+        hdu.add_keyword("CDELT1", pixscale_ra, "Pixscale" );
         hdu.add_keyword("CRVAL1", ra , "RA value in deg." ); // RA of the centre 
         hdu.add_keyword("CUNIT1", std::string { "deg"} , "" );
 
         hdu.add_keyword("CTYPE2", std::string {"DEC--SIN"}, "") ;
         hdu.add_keyword("CRPIX2", side_y / 2 + 1 , "" );   
-        hdu.add_keyword("CDELT2", pixscale , "Pixscale" );
+        hdu.add_keyword("CDELT2", pixscale_dec , "Pixscale" );
         hdu.add_keyword("CRVAL2", dec , "DEC value in deg." ); // RA of the centre 
         hdu.add_keyword("CUNIT2", std::string { "deg"} , "" );
     
@@ -43,17 +43,17 @@ void Images::to_fits_files(const std::string& directory_path, bool save_as_compl
             if(save_as_complex){
                 std::string filename {full_directory_str + "_image.fits"};
                 std::complex<float>* p_data = this->at(interval, fine_channel);
-                ::save_fits_file(filename, reinterpret_cast<float*>(p_data), this->side_size, this->side_size *2, ra_deg, dec_deg, pixscale[fine_channel]);
+                ::save_fits_file(filename, reinterpret_cast<float*>(p_data), this->side_size, this->side_size *2, ra_deg, dec_deg, pixscale_ra, pixscale_dec );
             }else{
                 for(size_t i {0}; i < this->image_size(); i++){
                     img_real[i] = current_data[i].real();
                 }
-                ::save_fits_file(full_directory_str + "_image_real.fits", img_real.data(), this->side_size, this->side_size, ra_deg, dec_deg, pixscale[fine_channel]);
+                ::save_fits_file(full_directory_str + "_image_real.fits", img_real.data(), this->side_size, this->side_size, ra_deg, dec_deg, pixscale_ra, pixscale_dec );
                 if(save_imaginary){
                     for(size_t i {0}; i < this->image_size(); i++){
                         img_imag[i] = current_data[i].imag();
                     }
-                    ::save_fits_file(full_directory_str + "_image_imag.fits", img_imag.data(), this->side_size, this->side_size, ra_deg, dec_deg, pixscale[fine_channel]);
+                    ::save_fits_file(full_directory_str + "_image_imag.fits", img_imag.data(), this->side_size, this->side_size, ra_deg, dec_deg, pixscale_ra, pixscale_dec );
                 }
             }
         }

--- a/src/images.hpp
+++ b/src/images.hpp
@@ -14,7 +14,7 @@ class Images : public MemoryBuffer<std::complex<float>> {
     unsigned int nFrequencies;
     unsigned int side_size;
     double ra_deg, dec_deg;
-    std::vector<double> pixscale;
+    double pixscale_ra, pixscale_dec; // separate pixscales for RA,DEC due to different UV coverage (MAX(u) and MAX(v))
 
    Images(MemoryBuffer<std::complex<float>>&& data, const ObservationInfo& obsInfo, unsigned int nIntegrationSteps,
             unsigned int nAveragedChannels, unsigned int side_size) : MemoryBuffer {std::move(data)} {


### PR DESCRIPTION
Using 2 pixscales for RA and DEC to account for different MAX of U and V.
Still need two more keywords as in the script fixCoordHdr.py which requires observatory coordinates and LST. These can be passed via ObservationInfo or some other way. To be discussed before changes applied.