### PR TITLE
Implements function to list .dat files in a directory.

### DIFF
--- a/src/astroio.cpp
+++ b/src/astroio.cpp
@@ -8,6 +8,7 @@
 #include <exception>
 #include "utils.hpp"
 #include "astroio.hpp"
+#include "files.hpp"
 
 extern const ObservationInfo VCS_OBSERVATION_INFO {
     .nAntennas = 128u,
@@ -455,3 +456,32 @@ std::vector<std::vector<DatFile>> parse_mwa_dat_files(std::vector<std::string>& 
     return observation;
 }
 
+
+/**
+ * @brief Get all the dat files in a directory. Optionally, only select the dat files corresponding
+ * to a certain range of seconds, specified with an offset from the first second and a count.
+ * 
+ * @param directory: path to the directory containing the .dat files
+ * @param offset: offset in number of seconds from the start of the observation.
+ * @param count: number of seconds to consider, starting from the offset.
+ * @todo Ideally we want to return a structured output that partitions input by observation and
+ * and then by groups of 24 files each representing 1 sencond of observation. Assume now a single
+ * observation, single 24 files.
+*/
+std::vector<std::vector<DatFile>> parse_mwa_dat_files(std::string directory, int offset, int count){
+    auto dat_files = blink::imager::list_files_in_dir(directory, ".dat");
+    // check that the selected range is valid. 24 is the number of coarse channels in a second.
+    int start_file_index = offset * 24;
+    if(count == -1) {
+        count = dat_files.size() / 24 - offset;
+    }
+    int file_count = count * 24;
+    if(start_file_index < 0 || start_file_index >= dat_files.size())
+        throw std::invalid_argument {"parse_mwa_dat_files: invalid start offset specifiled."};
+    if(file_count >= 0 && start_file_index + file_count > dat_files.size())
+        throw std::invalid_argument {"parse_mwa_dat_files: invalid count of seconds specifiled."};
+
+    std::sort(dat_files.begin(), dat_files.end());
+    auto selected_dat_files = std::vector<std::string>(dat_files.begin() + start_file_index, dat_files.begin() + start_file_index + file_count);
+    return parse_mwa_dat_files(selected_dat_files);
+}

--- a/src/astroio.cpp
+++ b/src/astroio.cpp
@@ -472,13 +472,13 @@ std::vector<std::vector<DatFile>> parse_mwa_dat_files(std::string directory, int
     auto dat_files = blink::imager::list_files_in_dir(directory, ".dat");
     // check that the selected range is valid. 24 is the number of coarse channels in a second.
     int start_file_index = offset * 24;
-    if(count == -1) {
+    if(count < 0) {
         count = dat_files.size() / 24 - offset;
     }
     int file_count = count * 24;
     if(start_file_index < 0 || start_file_index >= dat_files.size())
         throw std::invalid_argument {"parse_mwa_dat_files: invalid start offset specifiled."};
-    if(file_count >= 0 && start_file_index + file_count > dat_files.size())
+    if(start_file_index + file_count > dat_files.size())
         throw std::invalid_argument {"parse_mwa_dat_files: invalid count of seconds specifiled."};
 
     std::sort(dat_files.begin(), dat_files.end());

--- a/src/astroio.hpp
+++ b/src/astroio.hpp
@@ -303,4 +303,17 @@ ObservationInfo parse_mwa_phase1_dat_file_info(const std::string& file_path);
  * observation, single 24 files.
 */
 std::vector<std::vector<DatFile>> parse_mwa_dat_files(std::vector<std::string>& file_list);
+
+/**
+ * @brief Get all the dat files in a directory. Optionally, only select the dat files corresponding
+ * to a certain range of seconds, specified with an offset from the first second and a count.
+ * 
+ * @param directory: path to the directory containing the .dat files
+ * @param offset: offset in number of seconds from the start of the observation.
+ * @param count: number of seconds to consider, starting from the offset.
+ * @todo Ideally we want to return a structured output that partitions input by observation and
+ * and then by groups of 24 files each representing 1 sencond of observation. Assume now a single
+ * observation, single 24 files.
+*/
+std::vector<std::vector<DatFile>> parse_mwa_dat_files(std::string directory, int start_second = 0, int count = -1);
 #endif

--- a/src/files.cpp
+++ b/src/files.cpp
@@ -3,6 +3,17 @@
 #include <sys/types.h>
 #include <string>
 #include <string.h>
+#include <vector>
+
+namespace {
+    bool ends_with(std::string const &full_string, std::string const &ending) {
+        if (full_string.length() >= ending.length()) {
+            return (0 == full_string.compare(full_string.length() - ending.length(), ending.length(), ending));
+        } else {
+            return false;
+        }
+    }
+}
 
 namespace blink {
 
@@ -34,6 +45,35 @@ namespace blink {
             } else {
                 return false;
             }
+        }
+        
+        /**
+        @brief list all the files in a directory.
+
+        @param path: path of a directory.
+
+        @returns a vector of string objects representing the path to all files
+        in the given directory.
+        */
+        std::vector<std::string> list_files_in_dir(std::string path, std::string ext){
+            DIR *dir;
+            struct dirent *ent;
+            std::vector<std::string> files;
+            if((dir = opendir(path.c_str())) != NULL) {
+                while((ent = readdir(dir)) != NULL) {
+                    std::string fname {ent->d_name};
+                    if(ext.length() > 0){
+                        if(::ends_with(fname, ext))
+                            files.push_back(path + "/" + fname);
+                    }else{
+                        files.push_back(fname);
+                    }
+                }
+                closedir (dir);
+            } else {
+                throw std::runtime_error {"list_files_in_dir: error while opening the directory " + path};
+            }
+            return files;
         }
     }
 }

--- a/src/files.hpp
+++ b/src/files.hpp
@@ -18,5 +18,15 @@ namespace blink::imager {
      */
     void create_directory(const std::string& path);
 
+    /**
+    @brief list all the files in a directory.
+
+    @param path: path of a directory.
+
+    @returns a vector of string objects representing the path to all files
+    in the given directory.
+    */
+    std::vector<std::string> list_files_in_dir(std::string path, std::string ext = "");
+
 }
 #endif


### PR DESCRIPTION
I overloaded the function `parse_mwa_dat_files` so that it can also take the path to a directory, the start second index and the count. Then, the function selects the corresponding files and passes the list to the original `parse_mwa_dat_files` function. Beforehand, we would specify that list of files "manually" through the command line.

To implement this functionality I have added a `blink::imager::list_files_in_dir` function that, as the name says, lists all the files in a directory, and can optionally filter them by extension.

Notice how the namespace contains `imager::`. This has to be changed eventually to `astroio`. But did not want to introduce other changes, possibly in other unrelated files, in this PR. Eventually, I will clean up the code..
