### PR TITLE
Improves the `Images` class functionalities and fixes a bug in the FITS class.

### DIFF
--- a/src/FITS.cpp
+++ b/src/FITS.cpp
@@ -37,8 +37,8 @@ void FITS::HDU::set_image(int bitpix, char *data, long xDim, long yDim){
     if(this->data) delete[] static_cast<char*>(this->data);
     this->data = data;
     this->bitpix = bitpix;
-    axes[0] = yDim;
-    axes[1] = xDim;
+    axes[0] = xDim;
+    axes[1] = yDim;
     switch (bitpix){
     case FLOAT_IMG: 
         this->datatype = TFLOAT;
@@ -137,7 +137,7 @@ FITS FITS::from_file(std::string filename){
         // read data
         long fPixel[2] {1, 1};
         CHECK_FITS_ERROR(fits_read_pix(fptr, dataType, fPixel, axes[0] * axes[1], nullptr, data, nullptr, &status));
-        cHDU.set_image(bitPix, data, axes[1], axes[0]);
+        cHDU.set_image(bitPix, data, axes[0], axes[1]);
     }
     return fitsObj;
 }

--- a/src/FITS.hpp
+++ b/src/FITS.hpp
@@ -201,8 +201,8 @@ class FITS {
                 this->bitpix = LONG_IMG;
             }else 
                 throw std::invalid_argument {"set_image: data type of first argument not recognised."};
-            axes[0] = yDim;
-            axes[1] = xDim;
+            axes[0] = xDim;
+            axes[1] = yDim;
         }
 
 

--- a/src/astroio.cpp
+++ b/src/astroio.cpp
@@ -364,7 +364,7 @@ void Visibilities::to_fits_file(const std::string& filename) const{
         FITS::HDU hdu;
         std::complex<float>* pToMatrix = const_cast<std::complex<float>*>(this->data() + interval * (nFrequencies * this->matrix_size()));
         int msElapsed {static_cast<int>(interval *  (obsInfo.timeResolution * nIntegrationSteps * 1e3))};
-        hdu.set_image(reinterpret_cast<float*>(pToMatrix),  static_cast<long>(nFrequencies), static_cast<long>(this->matrix_size()) * 2);
+        hdu.set_image(reinterpret_cast<float*>(pToMatrix), static_cast<long>(this->matrix_size()) * 2, static_cast<long>(nFrequencies));
         hdu.add_keyword("TIME", static_cast<long>(obsInfo.startTime), "Unix time (seconds)");
         hdu.add_keyword("MILLITIM", msElapsed, "Milliseconds since TIME");
         hdu.add_keyword("INTTIME", integrationTime, "Integration time (s)");


### PR DESCRIPTION
This PR makes the following improvements to the `Images` class, and fixes a bug minor in the FITS class (see at the end).

## New method to save images

I have implemented the `Images::to_fits_file(size_t interval, size_t fine_channel, const std::string& directory_path, bool save_as_complex, bool save_imaginary)` method to save a single image, identified by internal (time bin) and fine channel. This method complements the `to_fits_files` one (notice the `s` at the end), which saves all images in the buffer. The logic that was previously in `to_fits_files` is now moved to `to_fits_file`, with the former now calling the latter to write FITS files. The auxiliary buffers are now private members of the class since they can be reused across calls to the method.

### Future possible improvements (even on this PR):
- The naming is a bit awkward and confusing: might be better to have an overloaded method called `save_to_fits`.
- Might add an option to only save non-flagged images

## Flagged images

The `images` class now has a member vector object (`std::vector<bool> flags`), and related methods (`set_flags`, `get_flags`, `is_flagged`) to deal with flagged images. These are set by the RFI flagging routine run in the pipeline.

### Future improvements

- This implementation currently only works on CPU. I need to change the `std::vector` type with `MemoryBuffer` and handles the case when the buffer is on GPU.

## Added `const` version of the `at` method

So It can be called on `const Images` objects. I also renamed the `frequency` argument to the more representative `fine_channel`.

## Fixing bug in FITS axis

The bug was simply swapping the X and Y axes when saving a FITS file. We did not notice it with the images because they are squares, and "to counter the bug", instead of fixing it for some reason, I was swapping  the dimensions arguments when saving the visibilties to FITS files, that that is why it was working in that case.

I only noticed this when saving the dynamic spectrum which has different dimensions for the X and Y axes.