### PR TITLE
fix bug - dump() is not const method of MemoryBuffer

### DIFF
--- a/src/gpu_macros.hpp
+++ b/src/gpu_macros.hpp
@@ -14,6 +14,7 @@ constexpr bool gpu_support() { return true;}
 // automatically when using "gpu*" calls.
 
 #ifdef __NVCC__
+#include <cuda_runtime.h>
 #define gpuError_t cudaError_t
 #define gpuSuccess cudaSuccess
 #define gpuGetErrorString cudaGetErrorString

--- a/src/memory_buffer.hpp
+++ b/src/memory_buffer.hpp
@@ -141,7 +141,7 @@ class MemoryBuffer {
     /**
      * @brief Dump contents to a binary file.
      */
-    void dump(std::string filename) const {
+    void dump(std::string filename) {
         this->to_cpu();
         std::ofstream outfile;
         outfile.open(filename, std::ofstream::binary);


### PR DESCRIPTION
Hi Cristian, this is the const removal patch